### PR TITLE
Fixed ItemResolver example

### DIFF
--- a/bundles/SyliusCartBundle/installation.rst
+++ b/bundles/SyliusCartBundle/installation.rst
@@ -250,6 +250,7 @@ This can be done in various ways, but to keep the example simple - we'll use que
     // src/App/AppBundle/Cart/ItemResolver.php
     namespace App\AppBundle\Cart;
 
+    use Sylius\Bundle\CartBundle\Model\CartItemInterface;
     use Sylius\Bundle\CartBundle\Model\CartItemRequest;
     use Sylius\Bundle\CartBundle\Resolver\ItemResolverInterface;
     use Sylius\Bundle\CartBundle\Resolver\ItemResolvingException;


### PR DESCRIPTION
Required `use` statement was missing.
