### PR TITLE
Update installation.rst

### DIFF
--- a/bundles/SyliusCartBundle/installation.rst
+++ b/bundles/SyliusCartBundle/installation.rst
@@ -213,6 +213,7 @@ This can be done in various ways, but to keep the example simple - we'll use que
     use Sylius\Bundle\CartBundle\Resolver\ItemResolverInterface;
     use Sylius\Bundle\CartBundle\Resolver\ItemResolvingException;
     use Symfony\Component\HttpFoundation\Request;
+    use Doctrine\ORM\EntityManager;
 
     class ItemResolver implements ItemResolverInterface
     {


### PR DESCRIPTION
We must include "use Doctrine\ORM\EntityManager" in ItemResolver otherwise it will try to resolve EntityManager manager in the current namespace of App/AppBundle/Cart/. 

Without 'use Doctrine\ORM\EntityManager' the following error is produced: PHP Catchable fatal error:  Argument 1 passed to app\AppBundle\Cart\ItemResolver::**construct() must be an instance of app\AppBundle\Cart\EntityManager, instance of EntityManager51cc9f23a10c7_546a8d27f194334ee012bfe64f629947b07e4919\__CG**\Doctrine\ORM\EntityManager given.
