### PR TITLE
fix installation instructions to not specify version 0.2.*

### DIFF
--- a/book/installation.rst
+++ b/book/installation.rst
@@ -12,7 +12,7 @@ If you have `Composer installed globally <http://getcomposer.org/doc/00-intro.md
 
 .. code-block:: bash
 
-    $ composer create-project -s dev sylius/sylius:0.2.*@dev
+    $ composer create-project -s dev sylius/sylius
 
 Otherwise you have to download .phar file.
 


### PR DESCRIPTION
i got an error with the version specified. as in the readme, it works fine.

   Could not find package sylius/sylius with version 0.2.*@dev.
