### PR TITLE
fix bad composer package name

### DIFF
--- a/guide/installation.rst
+++ b/guide/installation.rst
@@ -20,14 +20,14 @@ If you have `Composer installed globally <http://getcomposer.org/doc/00-intro.md
 
 .. code-block:: bash
 
-    $ composer create-project -s dev sylius/sylius
+    $ composer create-project -s dev sylius/sylius-standard
 
 Otherwise you have to download .phar file.
 
 .. code-block:: bash
 
     $ curl -sS https://getcomposer.org/installer | php
-    $ php composer.phar create-project -s dev sylius/sylius
+    $ php composer.phar create-project -s dev sylius/sylius-standard
 
 When all the dependencies are installed, you'll be asked to fill the ``parameters.yml`` file via interactive script.
 Please follow the guide and when everything is in place, finally run the following commands.


### PR DESCRIPTION
The package name is incoherent with the `cd` command.
And as the documentation is about installing the bundle for normal usage, it should point to the standard-edition, not the dev one.
