### PR TITLE
Update installation.rst

### DIFF
--- a/bundles/SyliusOrderBundle/installation.rst
+++ b/bundles/SyliusOrderBundle/installation.rst
@@ -85,20 +85,7 @@ You should create a mapping file in your ``AppBundle``, put it inside the doctri
                                                  http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
 
         <entity name="App\AppBundle\Entity\Order" table="app_order">
-            <id name="id" column="id" type="integer">
-                <generator strategy="AUTO" />
-            </id>
-            <one-to-many field="items" target-entity="Sylius\Component\Order\Model\OrderItemInterface" mapped-by="order" orphan-removal="true">
-                <cascade>
-                    <cascade-all/>
-                </cascade>
-            </one-to-many>
-
-            <one-to-many field="adjustments" target-entity="Sylius\Component\Order\Model\AdjustmentInterface" mapped-by="order" orphan-removal="true">
-                <cascade>
-                    <cascade-all/>
-                </cascade>
-            </one-to-many>
+  
         </entity>
 
     </doctrine-mapping>


### PR DESCRIPTION
Base mapping file Order.orm.xml has a mapped-superclass. Fields cannot be override this way and gives a message like:  Duplicate definition of column 'id' on entity <your entity> in a field or discriminator column mapping. Removing all content inside the entity tags means it will take the defaults, exactly what you want. When you want to override it: Read the doctrine documentation: http://doctrine-orm.readthedocs.org/en/latest/reference/inheritance-mapping.html#attribute-override
