### PR TITLE
Fix missing return

### DIFF
--- a/bundles/SyliusResourceBundle/configuration.rst
+++ b/bundles/SyliusResourceBundle/configuration.rst
@@ -72,6 +72,8 @@ You need to expose a semantic configuration for your bundle. The following examp
                     ->end()
                 ->end()
             ;
+
+            return $treeBuilder;
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Fixed tickets | n/a |
| License | MIT |

Fixed the missing return statement to return the `$treeBuilder`.
