### PR TITLE
Fixes typo in products.rst

### DIFF
--- a/book/products.rst
+++ b/book/products.rst
@@ -37,7 +37,7 @@ Every option type is represented by **ProductOption** and references multiple **
 Variants
 --------
 
-**ProductVariant** represents an unique combination of product options and can have its own pricing configuration, inventory tracking etc.
+**ProductVariant** represents a unique combination of product options and can have its own pricing configuration, inventory tracking etc.
 
 You are also able to use product variations system without the options at all.
 


### PR DESCRIPTION
an unique -> a unique

Details (see https://owl.english.purdue.edu/owl/resource/591/01/):

When "u" makes the same sound as the "y" in "you," or "o" makes the same sound as "w" in "won," then a is used. The word-initial "y" sound ("unicorn") is actually a glide [j] phonetically, which has consonantal properties; consequently, it is treated as a consonant, requiring "a."
- a union
- a united front
- a unicorn
- a used napkin
- a U.S. ship
