### PR TITLE
Correct the interface name for attribute subjects

### DIFF
--- a/components/Attribute/implementing_subject_interface.rst
+++ b/components/Attribute/implementing_subject_interface.rst
@@ -1,7 +1,7 @@
-Implementing SubjectInterface
-=============================
+Implementing AttributeSubjectInterface
+======================================
 
-To characterize an object using attribute, it needs to implement the **SubjectInterface** interface:
+To characterize an object with attributes, the object class needs to implement the ``AttributeSubjectInterface``.
 
 * ``getAttributes()``
 * ``setAttributes(Collection $attributes)``


### PR DESCRIPTION
Since commit  `2aa40ca` _[Attribute] Rename `SubjectInterface` into `AttributeSubjectInterface`_, the docs are still using the old name, so I have updated them with the new interface name.
