### PR TITLE
Add basic documentation for the AttributeBundle

### DIFF
--- a/bundles/SyliusAttributeBundle/configuration.rst
+++ b/bundles/SyliusAttributeBundle/configuration.rst
@@ -1,0 +1,26 @@
+Configuration reference
+=======================
+
+.. code-block:: yaml
+
+    sylius_attribute:
+          driver: ~ # The driver used for persistence layer. Currently only `doctrine/orm` is supported.
+          classes:
+              # `subject_name` can be any name, for example `product`, `ad`, or `blog_post`
+              subject_name:
+                  subject: ~ # Required: The subject class implementing `AttributeSubjectInterface`.
+                  attribute:
+                      model:      ~ # Required: The attribute model class implementing `AttributeInterface`.
+                      repository: ~ # Required: The repository class for the attribute.
+                      controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
+                      form:       Sylius\Bundle\AttributeBundle\Form\Type\AttributeType
+                  attribute_value:
+                      model:      ~ # Required: The attribute value model class implementing `AttributeValueInterface`.
+                      repository: ~ # Required: The repository class for the attribute value.
+                      controller: Sylius\Bundle\ResourceBundle\Controller\ResourceController
+                      form:       Sylius\Bundle\AttributeBundle\Form\Type\AttributeValueType
+          validation_groups:
+              # `subject_name` should be same name as the name key defined for the classes section above.
+              subject_name:
+                  property:         [ sylius ]
+                  product_property: [ sylius ]

--- a/bundles/SyliusAttributeBundle/configuration.rst
+++ b/bundles/SyliusAttributeBundle/configuration.rst
@@ -22,5 +22,5 @@ Configuration reference
           validation_groups:
               # `subject_name` should be same name as the name key defined for the classes section above.
               subject_name:
-                  property:         [ sylius ]
-                  product_property: [ sylius ]
+                  attribute:       [ sylius ]
+                  attribute_value: [ sylius ]

--- a/bundles/SyliusAttributeBundle/index.rst
+++ b/bundles/SyliusAttributeBundle/index.rst
@@ -1,0 +1,16 @@
+SyliusAttributeBundle
+=====================
+
+This bundle provides easy integration of the :doc:`Sylius Attribute component </components/Attribute/index>`
+with any Symfony full-stack application.
+
+Sylius uses this bundle internally for its product catalog to manage the different attributes that are specific to each
+product.
+
+
+.. toctree::
+    :maxdepth: 1
+    :numbered:
+
+    installation
+    configuration

--- a/bundles/SyliusAttributeBundle/installation.rst
+++ b/bundles/SyliusAttributeBundle/installation.rst
@@ -1,0 +1,85 @@
+Installation
+============
+
+We assume you're familiar with `Composer <http://packagist.org>`_, a dependency manager for PHP.
+Use the following command to add the bundle to your `composer.json` and download the package.
+
+If you have `Composer installed globally <http://getcomposer.org/doc/00-intro.md#globally>`_.
+
+.. code-block:: bash
+
+    $ composer require "sylius/attribute-bundle"
+
+Otherwise you have to download .phar file.
+
+.. code-block:: bash
+
+    $ curl -sS https://getcomposer.org/installer | php
+    $ php composer.phar require "sylius/attribute-bundle"
+
+Adding required bundles to the kernel
+-------------------------------------
+
+You need to enable the bundle inside the kernel.
+
+If you're not using any other Sylius bundles, you will also need to add `SyliusResourceBundle` and its dependencies to kernel.
+Don't worry, everything was automatically installed via Composer.
+
+.. code-block:: php
+
+    <?php
+
+    // app/AppKernel.php
+
+    public function registerBundles()
+    {
+        $bundles = array(
+            new FOS\RestBundle\FOSRestBundle(),
+            new JMS\SerializerBundle\JMSSerializerBundle($this),
+            new Stof\DoctrineExtensionsBundle\StofDoctrineExtensionsBundle(),
+            new WhiteOctober\PagerfantaBundle\WhiteOctoberPagerfantaBundle(),
+            new Sylius\Bundle\AttributeBundle\SyliusAttributeBundle(),
+            new Sylius\Bundle\ResourceBundle\SyliusResourceBundle(),
+
+            // Other bundles...
+            new Doctrine\Bundle\DoctrineBundle\DoctrineBundle(),
+        );
+    }
+
+.. note::
+
+    Please register the bundle before *DoctrineBundle*. This is important as we use listeners which have to be processed first.
+
+Container configuration
+-----------------------
+
+Put this configuration inside your ``app/config/config.yml``.
+
+.. code-block:: yaml
+
+    sylius_attribute:
+        driver: doctrine/orm # Configure the doctrine orm driver used in the documentation.
+
+And configure doctrine extensions which are used by the bundle.
+
+.. code-block:: yaml
+
+    stof_doctrine_extensions:
+        orm:
+            default:
+                timestampable: true
+
+Updating database schema
+------------------------
+
+Run the following command.
+
+.. code-block:: bash
+
+    $ php app/console doctrine:schema:update --force
+
+.. warning::
+
+    This should be done only in **dev** environment! We recommend using Doctrine migrations, to safely update your schema.
+
+Congratulations! The bundle is now installed and ready to use.

--- a/bundles/index.rst
+++ b/bundles/index.rst
@@ -19,5 +19,6 @@ Symfony2 Ecommerce Bundles
     SyliusSettingsBundle/index
     SyliusFlowBundle/index
     SyliusVariationBundle/index
+    SyliusAttributeBundle/index
 
 .. include:: /bundles/map.rst.inc

--- a/bundles/map.rst.inc
+++ b/bundles/map.rst.inc
@@ -14,4 +14,4 @@
 * :doc:`/bundles/SyliusFlowBundle/index`
 * :doc:`/bundles/SyliusContactBundle/index`
 * :doc:`/bundles/SyliusVariationBundle/index`
-
+* :doc:`/bundles/SyliusAttributeBundle/index`


### PR DESCRIPTION
Q  | A
----|----
Doc fix? | no
New docs? | yes
Fixed tickets | 

Interestingly whilst documenting the bundle configuration, I noticed that the `validation_groups` were named `property` and `product_property`.

Aside from the fact that the bundle should not aware of the concept of a `product`, am I right in thinking that `property` was the old name for the attribute?