### PR TITLE
Add how to enable listing tools in index_resources.rst

### DIFF
--- a/bundles/SyliusResourceBundle/index_resources.rst
+++ b/bundles/SyliusResourceBundle/index_resources.rst
@@ -171,6 +171,29 @@ Sorting your resources (sylius_resource_sort)
 +++++++++++++++++++++++++++++++++++++++++++++
 
 This TWIG extension renders the title of your columns (in your table), it created the link used to sort your resources.
+You will need to enable it per route
+
+.. code-block:: yaml
+
+    # routing.yml
+
+    app_user_index:
+        path: /users
+        methods: [GET]
+        defaults:
+            _controller: app.controller.user:indexAction
+            sortable: true
+
+or globally
+
+.. code-block:: yaml
+
+    # config.yml
+
+    sylius_resource:
+        settings:
+            sortable: true
+
 
 Parameters
 ##########
@@ -190,8 +213,29 @@ Parameters
 |           |           |         | **route_params (array) :** Additional route parameters   |
 +-----------+-----------+---------+----------------------------------------------------------+
 
-This extension renders the following template : SyliusResourceBundle:Twig:sorting.html.twig
+This extension renders the following template : SyliusResourceBundle:Twig:sorting.html.twig.
+You will need to enable it per route
 
+.. code-block:: yaml
+
+    # routing.yml
+
+    app_user_index:
+        path: /users
+        methods: [GET]
+        defaults:
+            _controller: app.controller.user:indexAction
+            paginate: $paginate
+
+or globally
+
+.. code-block:: yaml
+
+    # config.yml
+
+    sylius_resource:
+        settings:
+            paginate: $paginate
 Example
 #######
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Fixed tickets | no |

Hi,

Listing tools require configuration to work. Here it is.
Not sure if format is acceptable, but information is important. Spent more than an hour figuring this out.
