### PR TITLE
Fix the semantic configuration example for the Resource Bundle

### DIFF
--- a/bundles/SyliusResourceBundle/configuration.rst
+++ b/bundles/SyliusResourceBundle/configuration.rst
@@ -86,52 +86,54 @@ You need to expose a semantic configuration for your bundle. The following examp
             $rootNode = $treeBuilder->root('bundle_name');
 
             $rootNode
-                // Driver used by the resource bundle
-                ->scalarNode('driver')->isRequired()->cannotBeEmpty()->end()
+                ->children()
+                    // Driver used by the resource bundle
+                    ->scalarNode('driver')->isRequired()->cannotBeEmpty()->end()
 
-                // Object manager used by the resource bundle, if not specified "default" will used
-                ->scalarNode('manager')->defaultValue('default')->end()
+                    // Object manager used by the resource bundle, if not specified "default" will used
+                    ->scalarNode('manager')->defaultValue('default')->end()
 
-                // Validation groups used by the form component
-                ->arrayNode('validation_groups')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->arrayNode('MyEntity')
-                            ->prototype('scalar')->end()
-                            ->defaultValue(array('your_group'))
-                        ->end()
-                    ->end()
-                ->end()
-
-                // Configure the template namespace used by each resource
-                ->arrayNode('templates')
-                ->addDefaultsIfNotSet()
-                    ->children()
-                        ->scalarNode('my_entity')->defaultValue('MyCoreBundle:Entity')->end()
-                        ->scalarNode('my_other_entity')->defaultValue('MyOtherCoreBundle:Entity')->end()
-                    ->end()
-                ->end()
-
-
-                // The resources
-                ->arrayNode('classes')
-                    ->addDefaultsIfNotSet()
-                    ->children()
-                        ->arrayNode('my_entity')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('model')->defaultValue('MyApp\MyCustomBundle\Model\MyEntity')->end()
-                                ->scalarNode('controller')->defaultValue('Sylius\Bundle\ResourceBundle\Controller\ResourceController')->end()
-                                ->scalarNode('repository')->end()
-                                ->scalarNode('form')->defaultValue('MyApp\MyCustomBundle\Form\Type\MyformType')->end()
+                    // Validation groups used by the form component
+                    ->arrayNode('validation_groups')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->arrayNode('MyEntity')
+                                ->prototype('scalar')->end()
+                                ->defaultValue(array('your_group'))
                             ->end()
                         ->end()
-                        ->arrayNode('my_other_entity')
-                            ->addDefaultsIfNotSet()
-                            ->children()
-                                ->scalarNode('model')->defaultValue('MyApp\MyCustomBundle\Model\MyOtherEntity')->end()
-                                ->scalarNode('controller')->defaultValue('Sylius\Bundle\ResourceBundle\Controller\ResourceController')->end()
-                                ->scalarNode('form')->defaultValue('MyApp\MyCustomBundle\Form\Type\MyformType')->end()
+                    ->end()
+
+                    // Configure the template namespace used by each resource
+                    ->arrayNode('templates')
+                    ->addDefaultsIfNotSet()
+                        ->children()
+                            ->scalarNode('my_entity')->defaultValue('MyCoreBundle:Entity')->end()
+                            ->scalarNode('my_other_entity')->defaultValue('MyOtherCoreBundle:Entity')->end()
+                        ->end()
+                    ->end()
+
+
+                    // The resources
+                    ->arrayNode('classes')
+                        ->addDefaultsIfNotSet()
+                        ->children()
+                            ->arrayNode('my_entity')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('model')->defaultValue('MyApp\MyCustomBundle\Model\MyEntity')->end()
+                                    ->scalarNode('controller')->defaultValue('Sylius\Bundle\ResourceBundle\Controller\ResourceController')->end()
+                                    ->scalarNode('repository')->end()
+                                    ->scalarNode('form')->defaultValue('MyApp\MyCustomBundle\Form\Type\MyformType')->end()
+                                ->end()
+                            ->end()
+                            ->arrayNode('my_other_entity')
+                                ->addDefaultsIfNotSet()
+                                ->children()
+                                    ->scalarNode('model')->defaultValue('MyApp\MyCustomBundle\Model\MyOtherEntity')->end()
+                                    ->scalarNode('controller')->defaultValue('Sylius\Bundle\ResourceBundle\Controller\ResourceController')->end()
+                                    ->scalarNode('form')->defaultValue('MyApp\MyCustomBundle\Form\Type\MyformType')->end()
+                                ->end()
                             ->end()
                         ->end()
                     ->end()


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Doc fix? | yes |
| New docs? | no |
| Fixed tickets |  |

When following the steps to used the [advanced configuration](http://sylius.readthedocs.org/en/latest/bundles/SyliusResourceBundle/configuration.html#advanced-configuration) for my resource bundle, following the example for exposing the semantic configuration of the bundle will produce a fatal error:

```
Fatal error: Call to undefined method Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition::scalarNode()
```

To fix this, the root node should define `children` first:

``` php
$rootNode
    ->children()
        ->scalarNode('driver')->isRequired()->cannotBeEmpty()->end()
        // other nodes
    ->end()
;
```
