### PR TITLE
sylius_taxonomies doesn't exist

### DIFF
--- a/bundles/SyliusTaxonomyBundle/installation.rst
+++ b/bundles/SyliusTaxonomyBundle/installation.rst
@@ -60,7 +60,7 @@ Put this configuration inside your ``app/config/config.yml``.
 
 .. code-block:: yaml
 
-    sylius_taxonomies:
+    sylius_taxonomy:
         driver: doctrine/orm # Configure the doctrine orm driver used in documentation.
 
 And configure doctrine extensions which are used in the taxonomy bundle:


### PR DESCRIPTION
As I see from SyliusTaxonomyBundle configuration `sylius_taxonomies` doesn't exists. `sylius_taxonomy` should be used.