### PR TITLE
Fixed class name of RegisterCalculatorServicePass

### DIFF
--- a/cookbook/registry.rst
+++ b/cookbook/registry.rst
@@ -68,6 +68,8 @@ Finally, you need to register your custom pass with the container
 .. code-block:: php
 
     namespace App\Bundle\MyBundle;
+    
+    use App\Bundle\MyBundle\DependencyInjection\Compiler\RegisterCalculatorServicePass;
 
     class AppMyBundleBundle extends Bundle
     {
@@ -75,6 +77,6 @@ Finally, you need to register your custom pass with the container
         {
             parent::build($container);
 
-            $container->addCompilerPass(new RegisterServicePass());
+            $container->addCompilerPass(new RegisterCalculatorServicePass());
         }
     }


### PR DESCRIPTION
The class on line 36 doesn't match the one in old line 78. Now it does. Also includes the proper use statement.