### PR TITLE
[Bundles][General] Added "default" path when overriding forms

### DIFF
--- a/bundles/general/overriding_forms.rst
+++ b/bundles/general/overriding_forms.rst
@@ -40,7 +40,8 @@ Now, define the new form class in the ``app/config/config.yml``.
         driver: doctrine/orm
         classes:
             address:
-                form: Acme\ShopBundle\Form\Type\AddressType
+                form: 
+                    default: Acme\ShopBundle\Form\Type\AddressType
 
 Done! Sylius will now use your custom address form everywhere!
 


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Doc fix?  | yes  |
| New docs?   | no |
| Fixed tickets |	- |

The form configuration must have a "default" path in order to set the form class. Otherwise, it will throw an InvalidTypeException (Expected array, but got string)