### PR TITLE
Update taxonomy-bundle installation instruction

### DIFF
--- a/bundles/SyliusTaxonomyBundle/installation.rst
+++ b/bundles/SyliusTaxonomyBundle/installation.rst
@@ -62,6 +62,9 @@ Put this configuration inside your ``app/config/config.yml``.
 
     sylius_taxonomy:
         driver: doctrine/orm # Configure the doctrine orm driver used in documentation.
+        classes:
+            taxonomy: ~
+            taxon: ~ 
 
 And configure doctrine extensions which are used in the taxonomy bundle:
 


### PR DESCRIPTION
For some reason https://github.com/Sylius/Sylius/blob/master/src/Sylius/Bundle/TaxonomyBundle/DependencyInjection/Configuration.php#L97 is set to `Required`, which is why this PR required.

Maybe you will want to fix taxonomy configuration behaviour instead.