### PR TITLE
Fixed model class to be extended

### DIFF
--- a/bundles/general/overriding_models.rst
+++ b/bundles/general/overriding_models.rst
@@ -6,7 +6,7 @@ Overriding Models
 Extending base Models
 ---------------------
 
-All Sylius models live in ``Sylius\Component\Xyz\Model`` namespace together with the interfaces.
+All Sylius models live in ``Sylius\Component\Core\Model\Xyz`` namespace together with the interfaces.
 As an example, for **Sylius Taxation Component** it's *TaxCategory* and *TaxRate*.
 
 Let's assume you want to add "zone" field to the Sylius tax rates.
@@ -18,7 +18,7 @@ Firstly, you need to create your own ``TaxRate`` class, which will extend the ba
     namespace Acme\Bundle\ShopBundle\Entity;
 
     use Sylius\Component\Addressing\Model\ZoneInterface;
-    use Sylius\Component\Taxation\Model\TaxRate as BaseTaxRate;
+    use Sylius\Component\Core\Model\TaxRate as BaseTaxRate;
 
     class TaxRate extends BaseTaxRate
     {
@@ -76,4 +76,4 @@ What has happened?
 * ``sylius.controller.tax_rate`` represents the controller for your new class.
 * All Doctrine relations to ``Sylius\\Component\\Taxation\\Model\\TaxRateInterface`` are using your new class as *target-entity*, you do not need to update any mappings.
 * ``TaxRateType`` form type is using your model as ``data_class``.
-* ``Sylius\\Component\\Taxation\\Model\\TaxRate`` is automatically turned into Doctrine Mapped Superclass.
+* ``Sylius\\Component\\Core\\Model\\TaxRate`` is automatically turned into Doctrine Mapped Superclass.


### PR DESCRIPTION
| Q  | A |
| ------------- | ------------- |
| Doc fix?  | yes  |
| New docs?   | no |
| Fixed tickets |	https://github.com/Sylius/Sylius-Docs/issues/293 |

Custom models should extend core model class.

When trying to override Product model extending Sylius\Component\Product\Model\Product, it won't add all fields to the Product table in database.

- Extending Sylius\Component\Product\Model\Product as written in the docs:

| Column             | Type
| ------------- | ---
| id      | integer
| archetype_id  | integer
| available_on    | timestamp(0) without time zone
| created_at        | timestamp(0) without time zone
| updated_at | timestamp(0) without time zone
| deleted_at | timestamp(0) without time zone

- Extending Sylius\Component\Core\Model\Product (same table as the default installation):

| Column             | Type
| ------------- | ---
| id      | integer
| archetype_id  | integer
| tax_category_id    | integer
| shipping_category_id | integer
| restricted_zone | integer
| available_on    | timestamp(0) without time zone
| created_at        | timestamp(0) without time zone
| updated_at | timestamp(0) without time zone
| deleted_at | timestamp(0) without time zone
| variant_selection_method | character varying(255)

Probably the same happens to the other models as related here https://github.com/Sylius/Sylius-Docs/issues/293