### PR TITLE
Created a new line alias

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -22,3 +22,6 @@ sys.path.append(os.path.abspath('_exts'))
 lexers['php'] = PhpLexer(startinline=True)
 lexers['php-annotations'] = PhpLexer(startinline=True)
 primary_domain = 'php'
+rst_epilog = """
+.. include:: /newline.rst
+"""

--- a/newline.rst
+++ b/newline.rst
@@ -1,0 +1,3 @@
+.. |br| raw:: html
+
+    <br />


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | no
| New docs?     | no
| Fixed tickets | -

Created a quick alias ensuring a new line character, namely ```|br|``` in a file /newline.rst.
You can use this alias in any .rst file as it's being included to every file on build.