### PR TITLE
[Order] Change Adjustment description to label

### DIFF
--- a/components/Order/models.rst
+++ b/components/Order/models.rst
@@ -129,7 +129,7 @@ Adjustments have the following properties:
 +-----------------+-----------------------------------------+
 | type            | Type of the adjustment (e.g. "tax")     |
 +-----------------+-----------------------------------------+
-| description     | e.g. "Clothing Tax 9%"                  |
+| label           | e.g. "Clothing Tax 9%"                  |
 +-----------------+-----------------------------------------+
 | amount          | Adjustment amount                       |
 +-----------------+-----------------------------------------+


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix? | yes
| New docs?  | no
| Fixed tickets  |

Little fix in Adjustment model, due to field ``description`` name change to ``label``.