### PR TITLE
[ResourceBundle] In the config : should be "form", not "forms"

### DIFF
--- a/bundles/SyliusResourceBundle/forms.rst
+++ b/bundles/SyliusResourceBundle/forms.rst
@@ -42,7 +42,7 @@ Now, configure it under ``sylius_resource``:
             app.book:
                 classes:
                     model: AppBundle\Entity\Book
-                    forms:
+                    form:
                         default: AppBundle\Form\Type\BookType
 
 That's it. Your new class will be used for all forms!


### PR DESCRIPTION
Q | A
------------ | -------------
Doc fix? | yes
New docs? | no

(according to the Configuration class)